### PR TITLE
clear cache on flush

### DIFF
--- a/src/database/disk_db.rs
+++ b/src/database/disk_db.rs
@@ -65,5 +65,6 @@ impl<S: BatchDB> Flush for VerkleTreeDb<GenericBatchDB<S>> {
         self.storage.flush(w.inner);
 
         self.batch.clear();
+        self.cache.clear();
     }
 }

--- a/src/database/memory_db.rs
+++ b/src/database/memory_db.rs
@@ -70,5 +70,6 @@ impl<T: ReadOnlyHigherDb + WriteOnlyHigherDb> Flush for VerkleTreeDb<GenericMemo
         );
 
         self.batch.clear();
+        self.cache.clear();
     }
 }

--- a/tests/db_trie_test.rs
+++ b/tests/db_trie_test.rs
@@ -54,7 +54,7 @@ mod db_trie_test_helper {
 
         let trie_2 = create_trie_from_db(CommitScheme::TestCommitment, db);
         let val = verkle_trie_get(trie_2, one32);
-        val.is_null();
+        assert!(val.is_null());
     }
 
     pub fn create_trie_from_flushed_db(db_scheme: DatabaseScheme) {
@@ -108,13 +108,19 @@ mod db_trie_test_helper {
         assert_value(val, _ONE32);
 
         let val = verkle_trie_get(trie, one);
-        val.is_null();
+        assert_value(val, _ONE);
+
+        verkle_trie_flush(trie_2);
+
+        let val = verkle_trie_get(trie_2, one);
+        assert_value(val, _ONE32);
 
         clear_temp_changes_read_only_db(ro_db);
 
-        let val = verkle_trie_get(trie, one);
-        val.is_null();
+        let val = verkle_trie_get(trie_2, one);
+        assert_value(val, _ONE);
     }
+
 }
 
 macro_rules! db_trie_test {


### PR DESCRIPTION
this is not the optimal solution, instead cache should be implemented over the db itself
there is no need for cahce in trie. this would not affect the correctness of the impl
but would affect the performance